### PR TITLE
Fixed datasets module references in prepare-wiki.sh

### DIFF
--- a/prepare_wiki.sh
+++ b/prepare_wiki.sh
@@ -46,8 +46,8 @@ else
   echo "${EXTR_PATH} already exists. Skipping extraction."
 fi
 
-python -m multifit.create_wikitext -i "${EXTR_PATH}"  -l "${LANG}" -o "${WIKI_DIR}"
+python -m multifit.datasets.create_wikitext -i "${EXTR_PATH}"  -l "${LANG}" -o "${WIKI_DIR}"
 
-python -m multifit.postprocess_wikitext "${WIKI_DIR}/${LANG}-2" $LANG
-python -m multifit.postprocess_wikitext "${WIKI_DIR}/${LANG}-100" $LANG
-#python -m multifit.postprocess_wikitext "${WIKI_DIR}/${LANG}-all" $LANG
+python -m multifit.datasets.postprocess_wikitext "${WIKI_DIR}/${LANG}-2" $LANG
+python -m multifit.datasets.postprocess_wikitext "${WIKI_DIR}/${LANG}-100" $LANG
+#python -m multifit.datasets.postprocess_wikitext "${WIKI_DIR}/${LANG}-all" $LANG


### PR DESCRIPTION
Had the following errors otherwise:

```
Saving data in data
Chosen language: it
data/wiki_dumps/itwiki-latest-pages-articles.xml.bz2 already exists. Skipping download.
data/wiki_extr/it already exists. Skipping extraction.
/src/fastai/.venv/bin/python: No module named multifit.create_wikitext
/src/fastai/.venv/bin/python: No module named multifit.postprocess_wikitext
/src/fastai/.venv/bin/python: No module named multifit.postprocess_wikitext
```
